### PR TITLE
Fix execution error check

### DIFF
--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -73,12 +73,13 @@ export class WorkflowRunner {
 		// FIXME: This is a quick fix. The proper fix would be to not remove
 		// the execution from the active executions while it's still running.
 		if (
-			error instanceof ExecutionNotFoundError ||
-			error instanceof ExecutionCancelledError ||
-			error.message.includes('cancelled')
-		) {
-			return;
-		}
+                       error instanceof ExecutionNotFoundError ||
+                       error instanceof ExecutionCancelledError ||
+                       error.message.toLowerCase().includes('cancelled') ||
+                       error.message.toLowerCase().includes('canceled')
+               ) {
+                       return;
+               }
 
 		this.logger.error(`Problem with execution ${executionId}: ${error.message}. Aborting.`);
 		this.errorReporter.error(error, { executionId });


### PR DESCRIPTION
## Summary
- refine cancelation detection in workflow runner

## Testing
- `pnpm biome check packages/cli/src/workflow-runner.ts` *(fails: Command "biome" not found)*
- `pnpm test` *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840015ae2a08330aeeec6db7bf3c0f0